### PR TITLE
feat: add custom Chrome binary path support

### DIFF
--- a/cmd/chrome_path_example/README.md
+++ b/cmd/chrome_path_example/README.md
@@ -1,0 +1,40 @@
+# Chrome Path Example
+
+测试如何指定自定义 Chrome 路径的示例程序。
+
+## 使用方法
+
+```bash
+# 构建
+go build -o chrome_path_example
+
+# 显示当前系统的常见 Chrome 路径
+./chrome_path_example -show-paths
+
+# 自动检测系统中的 Chrome
+./chrome_path_example -auto-detect
+
+# 使用自定义路径 (macOS 示例)
+./chrome_path_example -chrome-path="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+# 使用自定义路径并在非 headless 模式运行（可以看到浏览器窗口）
+./chrome_path_example -chrome-path="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" -headless=false
+
+# 让 launcher 自动下载或查找 Chrome（不指定任何路径）
+./chrome_path_example
+```
+
+## 命令行参数
+
+- `-chrome-path string`: 自定义 Chrome/Chromium 可执行文件路径
+- `-headless`: 在 headless 模式下运行（默认: false，会显示浏览器窗口）
+- `-auto-detect`: 使用 launcher.LookPath() 自动检测 Chrome 路径
+- `-show-paths`: 显示当前操作系统的常见 Chrome 路径
+
+## 测试功能
+
+程序会：
+1. 根据参数创建浏览器实例
+2. 导航到 example.com
+3. 获取并打印页面标题
+4. 验证浏览器功能正常

--- a/cmd/chrome_path_example/main.go
+++ b/cmd/chrome_path_example/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"runtime"
+
+	"github.com/go-rod/rod/lib/launcher"
+	headless_browser "github.com/xpzouying/headless_browser"
+)
+
+func main() {
+	var (
+		chromePath = flag.String("chrome-path", "", "Custom Chrome/Chromium executable path")
+		headless   = flag.Bool("headless", false, "Run in headless mode")
+		autoDetect = flag.Bool("auto-detect", false, "Auto-detect Chrome path using launcher.LookPath()")
+		showPaths  = flag.Bool("show-paths", false, "Show common Chrome paths for current OS")
+	)
+	flag.Parse()
+
+	if *showPaths {
+		showCommonPaths()
+		return
+	}
+
+	// 确定要使用的 Chrome 路径
+	var finalPath string
+	if *autoDetect {
+		if path, exists := launcher.LookPath(); exists {
+			finalPath = path
+			fmt.Printf("Auto-detected Chrome path: %s\n", path)
+		} else {
+			log.Fatal("Could not auto-detect Chrome path")
+		}
+	} else if *chromePath != "" {
+		finalPath = *chromePath
+		fmt.Printf("Using custom Chrome path: %s\n", finalPath)
+	} else {
+		fmt.Println("No Chrome path specified, launcher will auto-download or find Chrome")
+	}
+
+	// 创建浏览器实例
+	var browser *headless_browser.Browser
+	if finalPath != "" {
+		browser = headless_browser.New(
+			headless_browser.WithChromeBinPath(finalPath),
+			headless_browser.WithHeadless(*headless),
+		)
+	} else {
+		browser = headless_browser.New(
+			headless_browser.WithHeadless(*headless),
+		)
+	}
+	defer browser.Close()
+
+	// 测试导航
+	fmt.Println("Creating new page...")
+	page := browser.NewPage()
+
+	fmt.Println("Navigating to example.com...")
+	page.MustNavigate("https://example.com")
+
+	title := page.MustInfo().Title
+	fmt.Printf("Page title: %s\n", title)
+
+	fmt.Println("Test completed successfully!")
+}
+
+func showCommonPaths() {
+	fmt.Println("Common Chrome/Chromium paths for", runtime.GOOS)
+	fmt.Println()
+
+	switch runtime.GOOS {
+	case "darwin":
+		fmt.Println("macOS:")
+		fmt.Println("  Chrome:")
+		fmt.Println("    /Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+		fmt.Println("  Chrome Canary:")
+		fmt.Println("    /Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary")
+		fmt.Println("  Chromium:")
+		fmt.Println("    /Applications/Chromium.app/Contents/MacOS/Chromium")
+		fmt.Println("  Edge:")
+		fmt.Println("    /Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge")
+		fmt.Println("  Brave:")
+		fmt.Println("    /Applications/Brave Browser.app/Contents/MacOS/Brave Browser")
+
+	case "linux":
+		fmt.Println("Linux:")
+		fmt.Println("  Chrome:")
+		fmt.Println("    /usr/bin/google-chrome")
+		fmt.Println("    /opt/google/chrome/chrome")
+		fmt.Println("  Chromium:")
+		fmt.Println("    /usr/bin/chromium")
+		fmt.Println("    /usr/bin/chromium-browser")
+		fmt.Println("    /snap/bin/chromium")
+		fmt.Println("  Edge:")
+		fmt.Println("    /usr/bin/microsoft-edge")
+		fmt.Println("    /opt/microsoft/msedge/msedge")
+
+	case "windows":
+		fmt.Println("Windows:")
+		fmt.Println("  Chrome:")
+		fmt.Println("    C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe")
+		fmt.Println("    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
+		fmt.Println("  Edge:")
+		fmt.Println("    C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe")
+		fmt.Println("  Chromium:")
+		fmt.Println("    C:\\Program Files\\Chromium\\Application\\chrome.exe")
+
+	default:
+		fmt.Println("Unknown OS:", runtime.GOOS)
+	}
+
+	fmt.Println("\nTip: Use -auto-detect flag to automatically find Chrome on your system")
+}

--- a/headless_browser.go
+++ b/headless_browser.go
@@ -19,9 +19,10 @@ type Browser struct {
 
 // Config holds the configuration options for the browser.
 type Config struct {
-	Headless  bool   // Whether to run browser in headless mode
-	UserAgent string // Custom user agent string
-	Cookies   string // JSON string of cookies to set
+	Headless     bool   // Whether to run browser in headless mode
+	UserAgent    string // Custom user agent string
+	Cookies      string // JSON string of cookies to set
+	ChromeBinPath string // Custom Chrome/Chromium executable path
 }
 
 // Option is a functional option for configuring the browser.
@@ -33,6 +34,7 @@ func newDefaultConfig() *Config {
 		Headless:  true,
 		UserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
 		Cookies:   "",
+		ChromeBinPath: "", // Empty means auto-detect
 	}
 }
 
@@ -58,6 +60,18 @@ func WithCookies(cookies string) Option {
 	}
 }
 
+// WithChromeBinPath sets a custom Chrome/Chromium executable path.
+// If not set or empty, launcher will auto-detect or download a browser.
+// Common paths:
+//   - macOS: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+//   - Linux: "/usr/bin/google-chrome" or "/usr/bin/chromium"
+//   - Windows: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+func WithChromeBinPath(path string) Option {
+	return func(c *Config) {
+		c.ChromeBinPath = path
+	}
+}
+
 // New creates a new Browser instance with the provided options.
 // It initializes a Chrome browser with stealth mode enabled.
 func New(options ...Option) *Browser {
@@ -66,14 +80,19 @@ func New(options ...Option) *Browser {
 		option(cfg)
 	}
 
-	launcher := launcher.New().
+	l := launcher.New().
 		Headless(cfg.Headless).
 		Set("--no-sandbox").
 		Set(
 			"user-agent", cfg.UserAgent,
 		)
 
-	url := launcher.MustLaunch()
+	// Set custom Chrome binary path if provided
+	if cfg.ChromeBinPath != "" {
+		l = l.Bin(cfg.ChromeBinPath)
+	}
+
+	url := l.MustLaunch()
 
 	browser := rod.New().
 		ControlURL(url).
@@ -92,7 +111,7 @@ func New(options ...Option) *Browser {
 
 	return &Browser{
 		browser:  browser,
-		launcher: launcher,
+		launcher: l,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Added support for specifying custom Chrome/Chromium binary paths
- Allows users to use system-installed browsers instead of auto-downloaded ones
- Provides flexibility for different deployment environments

## Changes
- Added `ChromeBinPath` field to Config struct
- Created `WithChromeBinPath()` option function
- Updated `New()` function to use `launcher.Bin()` when custom path is provided
- Added comprehensive test example in `cmd/chrome_path_example/`

## Test plan
Run the example to test different Chrome path configurations:
```bash
# Show common Chrome paths for your OS
go run cmd/chrome_path_example/main.go -show-paths

# Auto-detect Chrome on your system
go run cmd/chrome_path_example/main.go -auto-detect

# Use custom Chrome path (macOS example)
go run cmd/chrome_path_example/main.go -chrome-path="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
```

🤖 Generated with [Claude Code](https://claude.ai/code)