### PR TITLE
feat: add proxy support

### DIFF
--- a/headless_browser.go
+++ b/headless_browser.go
@@ -23,6 +23,7 @@ type Config struct {
 	UserAgent     string // Custom user agent string
 	Cookies       string // JSON string of cookies to set
 	ChromeBinPath string // Custom Chrome/Chromium executable path
+	Proxy         string // Proxy server URL (e.g. "http://host:port", "socks5://host:port")
 
 	Trace bool // Whether to enable tracing (not implemented yet)
 }
@@ -75,6 +76,19 @@ func WithChromeBinPath(path string) Option {
 	}
 }
 
+// WithProxy sets a proxy server for all browser requests.
+// Supports HTTP, HTTPS, and SOCKS5 proxies.
+// Example: "http://proxy.example.com:8080", "socks5://127.0.0.1:1080"
+//
+// Note: Chrome's --proxy-server flag does not support embedded credentials
+// (e.g. "http://user:pass@host:port"). For authenticated proxies, handle
+// authentication separately at the page level.
+func WithProxy(proxy string) Option {
+	return func(c *Config) {
+		c.Proxy = proxy
+	}
+}
+
 func WithTrace() Option {
 	return func(c *Config) {
 		c.Trace = true
@@ -99,6 +113,11 @@ func New(options ...Option) *Browser {
 	// Set custom Chrome binary path if provided
 	if cfg.ChromeBinPath != "" {
 		l = l.Bin(cfg.ChromeBinPath)
+	}
+
+	// Set proxy server if provided
+	if cfg.Proxy != "" {
+		l = l.Proxy(cfg.Proxy)
 	}
 
 	url := l.MustLaunch()


### PR DESCRIPTION
## Summary

- Add `Proxy` field to `Config` struct
- Add `WithProxy()` option function  
- Use go-rod's built-in `l.Proxy()` method to apply proxy settings

## Related

This PR is inspired by #6 (thanks @Daily-AC for the contribution and suggestion!). Key improvements over #6:

- **Use go-rod built-in API**: Use `l.Proxy()` instead of raw `l.Set("--proxy-server", ...)`, which is safer and consistent with the framework
- **No unnecessary log output**: As a library, we should not force log output on callers
- **No extra dependencies**: Removed `maskProxyCredentials` and `net/url` import that are not needed
- **Document limitations**: Chrome's `--proxy-server` does not support embedded credentials (e.g. `http://user:pass@host:port`), this is noted in the doc comment

Closes #6

## Test plan

- [ ] Verify `WithProxy("http://proxy:8080")` correctly launches Chrome with proxy
- [ ] Verify `WithProxy("socks5://127.0.0.1:1080")` works with SOCKS5 proxy
- [ ] Verify omitting `WithProxy` has no effect (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)