### PR TITLE
feat: add authenticated proxy support for SOCKS5/HTTP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xpzouying/headless_browser
 
-go 1.23.1
+go 1.25.0
 
 require (
 	github.com/go-rod/rod v0.116.2
@@ -14,5 +14,6 @@ require (
 	github.com/ysmood/got v0.40.0 // indirect
 	github.com/ysmood/gson v0.7.3 // indirect
 	github.com/ysmood/leakless v0.9.0 // indirect
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	golang.org/x/net v0.51.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,12 @@ github.com/ysmood/gson v0.7.3/go.mod h1:3Kzs5zDl21g5F/BlLTNcuAGAYLKt2lV5G8D1zF3R
 github.com/ysmood/leakless v0.8.0/go.mod h1:R8iAXPRaG97QJwqxs74RdwzcRHT1SWCGTNqY8q0JvMQ=
 github.com/ysmood/leakless v0.9.0 h1:qxCG5VirSBvmi3uynXFkcnLMzkphdh3xx5FtrORwDCU=
 github.com/ysmood/leakless v0.9.0/go.mod h1:R8iAXPRaG97QJwqxs74RdwzcRHT1SWCGTNqY8q0JvMQ=
+golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
+golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/headless_browser.go
+++ b/headless_browser.go
@@ -3,6 +3,7 @@ package headless_browser
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
@@ -13,8 +14,9 @@ import (
 
 // Browser represents a headless browser instance with an underlying rod.Browser and launcher.
 type Browser struct {
-	browser  *rod.Browser
-	launcher *launcher.Launcher
+	browser         *rod.Browser
+	launcher        *launcher.Launcher
+	proxyForwarder  *ProxyForwarder // 代理转发器
 }
 
 // Config holds the configuration options for the browser.
@@ -23,7 +25,7 @@ type Config struct {
 	UserAgent     string // Custom user agent string
 	Cookies       string // JSON string of cookies to set
 	ChromeBinPath string // Custom Chrome/Chromium executable path
-	Proxy         string // Proxy server URL (e.g. "http://host:port", "socks5://host:port")
+	Proxy         string // Proxy server URL (e.g. "http://host:port", "socks5://user:pass@host:port")
 
 	Trace bool // Whether to enable tracing (not implemented yet)
 }
@@ -78,11 +80,13 @@ func WithChromeBinPath(path string) Option {
 
 // WithProxy sets a proxy server for all browser requests.
 // Supports HTTP, HTTPS, and SOCKS5 proxies.
-// Example: "http://proxy.example.com:8080", "socks5://127.0.0.1:1080"
 //
-// Note: Chrome's --proxy-server flag does not support embedded credentials
-// (e.g. "http://user:pass@host:port"). For authenticated proxies, handle
-// authentication separately at the page level.
+// Examples:
+//   - Without authentication: "http://proxy.example.com:8080", "socks5://127.0.0.1:1080"
+//   - With authentication: "http://user:pass@proxy.example.com:8080", "socks5://user:pass@127.0.0.1:1080"
+//
+// For authenticated proxies, a local forwarder will be automatically created
+// to handle the authentication.
 func WithProxy(proxy string) Option {
 	return func(c *Config) {
 		c.Proxy = proxy
@@ -115,9 +119,32 @@ func New(options ...Option) *Browser {
 		l = l.Bin(cfg.ChromeBinPath)
 	}
 
-	// Set proxy server if provided
-	if cfg.Proxy != "" {
-		l = l.Proxy(cfg.Proxy)
+	// 处理代理设置
+	var proxyForwarder *ProxyForwarder
+	proxyURL := cfg.Proxy
+
+	if proxyURL != "" {
+		// 检查是否需要代理转发（带认证的代理）
+		parsed, err := url.Parse(proxyURL)
+		if err == nil && parsed.User != nil {
+			// 带认证的代理，创建本地转发器
+			proxyForwarder, err = NewProxyForwarder(proxyURL)
+			if err != nil {
+				logrus.Errorf("failed to create proxy forwarder: %v", err)
+				// 继续使用原代理 URL，让 Chrome 自己处理
+			} else {
+				if err := proxyForwarder.Start(); err != nil {
+					logrus.Errorf("failed to start proxy forwarder: %v", err)
+				} else {
+					// 使用本地转发器地址
+					proxyURL = "http://" + proxyForwarder.GetLocalAddr()
+					logrus.Infof("Using authenticated proxy via local forwarder: %s", proxyURL)
+				}
+			}
+		}
+
+		// 设置代理
+		l = l.Proxy(proxyURL)
 	}
 
 	url := l.MustLaunch()
@@ -138,8 +165,9 @@ func New(options ...Option) *Browser {
 	}
 
 	return &Browser{
-		browser:  browser,
-		launcher: l,
+		browser:        browser,
+		launcher:       l,
+		proxyForwarder: proxyForwarder,
 	}
 }
 
@@ -147,6 +175,13 @@ func New(options ...Option) *Browser {
 func (b *Browser) Close() {
 	b.browser.MustClose()
 	b.launcher.Cleanup()
+
+	// 停止代理转发器
+	if b.proxyForwarder != nil {
+		if err := b.proxyForwarder.Stop(); err != nil {
+			logrus.Errorf("failed to stop proxy forwarder: %v", err)
+		}
+	}
 }
 
 // NewPage creates a new page with stealth mode enabled.

--- a/proxy_forwarder.go
+++ b/proxy_forwarder.go
@@ -1,0 +1,340 @@
+package headless_browser
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/proxy"
+)
+
+// ProxyForwarder 本地代理转发器，用于支持带认证的远程代理
+type ProxyForwarder struct {
+	localAddr   string       // 本地监听地址
+	remoteProxy *url.URL     // 远程代理地址
+	server      *http.Server // HTTP 服务器
+	listener    net.Listener // 监听器
+	running     bool         // 是否正在运行
+	mu          sync.Mutex   // 并发锁
+	connectOnce sync.Once    // 确保只启动一次
+}
+
+// NewProxyForwarder 创建代理转发器
+// proxyURL 格式: "http://user:pass@host:port" 或 "socks5://user:pass@host:port"
+func NewProxyForwarder(proxyURL string) (*ProxyForwarder, error) {
+	// 解析代理 URL
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse proxy URL: %w", err)
+	}
+
+	// 获取一个可用的本地端口
+	addr, err := getAvailableLocalAddr()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local address: %w", err)
+	}
+
+	return &ProxyForwarder{
+		localAddr:   addr,
+		remoteProxy: parsed,
+	}, nil
+}
+
+// Start 启动本地代理转发服务器
+func (pf *ProxyForwarder) Start() error {
+	var startErr error
+	pf.connectOnce.Do(func() {
+		pf.mu.Lock()
+		defer pf.mu.Unlock()
+
+		// 创建监听器
+		listener, err := net.Listen("tcp", pf.localAddr)
+		if err != nil {
+			startErr = fmt.Errorf("failed to listen on %s: %w", pf.localAddr, err)
+			return
+		}
+		pf.listener = listener
+
+		// 获取实际监听地址（可能分配了不同端口）
+		pf.localAddr = listener.Addr().String()
+
+		// 创建 HTTP 代理服务器
+		pf.server = &http.Server{
+			Handler: http.HandlerFunc(pf.handleRequest),
+		}
+
+		pf.running = true
+
+		// 启动服务器（异步）
+		go func() {
+			if err := pf.server.Serve(listener); err != nil && err != http.ErrServerClosed {
+				logrus.Errorf("proxy forwarder error: %v", err)
+			}
+		}()
+
+		logrus.Infof("Proxy forwarder started: %s -> %s",
+			pf.localAddr, maskURL(pf.remoteProxy))
+	})
+
+	return startErr
+}
+
+// GetLocalAddr 获取本地代理地址
+func (pf *ProxyForwarder) GetLocalAddr() string {
+	return pf.localAddr
+}
+
+// Stop 停止代理转发器
+func (pf *ProxyForwarder) Stop() error {
+	pf.mu.Lock()
+	defer pf.mu.Unlock()
+
+	if !pf.running {
+		return nil
+	}
+
+	pf.running = false
+
+	if pf.server != nil {
+		if err := pf.server.Shutdown(context.Background()); err != nil {
+			// Shutdown 失败可能是正常的，继续关闭
+			logrus.Debugf("server shutdown error: %v", err)
+		}
+	}
+
+	if pf.listener != nil {
+		if err := pf.listener.Close(); err != nil {
+			return fmt.Errorf("failed to close listener: %w", err)
+		}
+	}
+
+	logrus.Info("Proxy forwarder stopped")
+	return nil
+}
+
+// handleRequest 处理代理请求
+func (pf *ProxyForwarder) handleRequest(w http.ResponseWriter, r *http.Request) {
+	// 确保请求 URI 为空（代理模式）
+	r.RequestURI = ""
+
+	// 根据代理类型处理
+	if pf.remoteProxy.Scheme == "socks5" {
+		pf.handleViaSOCKS5(w, r)
+	} else {
+		pf.handleViaHTTP(w, r)
+	}
+}
+
+// handleViaHTTP 通过 HTTP/HTTPS 代理转发请求
+func (pf *ProxyForwarder) handleViaHTTP(w http.ResponseWriter, r *http.Request) {
+	// 创建 HTTP 传输层，通过远程代理
+	transport := &http.Transport{
+		Proxy: func(*http.Request) (*url.URL, error) {
+			return pf.remoteProxy, nil
+		},
+	}
+
+	// 创建 HTTP 客户端
+	client := &http.Client{
+		Transport: transport,
+	}
+
+	// 发送请求
+	resp, err := client.Do(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("proxy error: %v", err), http.StatusBadGateway)
+		logrus.Errorf("HTTP proxy error: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// 复制响应头
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	// 设置状态码
+	w.WriteHeader(resp.StatusCode)
+
+	// 复制响应体
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		logrus.Errorf("error copying response: %v", err)
+	}
+}
+
+// handleViaSOCKS5 通过 SOCKS5 代理转发请求
+func (pf *ProxyForwarder) handleViaSOCKS5(w http.ResponseWriter, r *http.Request) {
+	// 处理 CONNECT 方法（用于 HTTPS）
+	if r.Method == "CONNECT" {
+		pf.handleHTTPSViaSOCKS5(w, r)
+		return
+	}
+
+	// HTTP 请求
+	pf.handleHTTPViaSOCKS5(w, r)
+}
+
+// handleHTTPViaSOCKS5 通过 SOCKS5 代理转发 HTTP 请求
+func (pf *ProxyForwarder) handleHTTPViaSOCKS5(w http.ResponseWriter, r *http.Request) {
+	// 创建 SOCKS5 拨号器
+	dialer, err := pf.createSOCKS5Dialer()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("socks5 error: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	// 构建目标地址
+	targetHost := r.URL.Host
+	if targetHost == "" {
+		targetHost = r.Host
+	}
+
+	// 通过 SOCKS5 连接
+	conn, err := dialer.(interface {
+		Dial(network, addr string) (net.Conn, error)
+	}).Dial("tcp", targetHost)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("socks5 connect error: %v", err), http.StatusBadGateway)
+		logrus.Errorf("SOCKS5 dial error: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	// 发送 HTTP 请求
+	if err := r.Write(conn); err != nil {
+		http.Error(w, fmt.Sprintf("socks5 write error: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	// 读取响应
+	resp, err := http.ReadResponse(bufio.NewReader(conn), r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("socks5 read error: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// 复制响应头
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	// 设置状态码
+	w.WriteHeader(resp.StatusCode)
+
+	// 复制响应体
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		logrus.Errorf("error copying response: %v", err)
+	}
+}
+
+// handleHTTPSViaSOCKS5 通过 SOCKS5 代理处理 HTTPS CONNECT 请求
+func (pf *ProxyForwarder) handleHTTPSViaSOCKS5(w http.ResponseWriter, r *http.Request) {
+	// 创建 SOCKS5 拨号器
+	dialer, err := pf.createSOCKS5Dialer()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("socks5 error: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	// 获取目标主机和端口
+	host := r.URL.Host
+	if host == "" {
+		host = r.Host
+	}
+
+	// 通过 SOCKS5 连接目标服务器
+	conn, err := dialer.(interface {
+		Dial(network, addr string) (net.Conn, error)
+	}).Dial("tcp", host)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("socks5 connect error: %v", err), http.StatusServiceUnavailable)
+		logrus.Errorf("SOCKS5 CONNECT error: %v", err)
+		return
+	}
+
+	// 发送 200 Connection established
+	w.WriteHeader(http.StatusOK)
+
+	// 获取底层的 TCP 连接（如果支持 hijack）
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		conn.Close()
+		return
+	}
+
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("hijack error: %v", err), http.StatusInternalServerError)
+		conn.Close()
+		return
+	}
+	defer clientConn.Close()
+	defer conn.Close()
+
+	// 双向转发数据
+	go func() {
+		defer clientConn.Close()
+		defer conn.Close()
+		io.Copy(conn, clientConn)
+	}()
+	io.Copy(clientConn, conn)
+}
+
+// createSOCKS5Dialer 创建 SOCKS5 拨号器
+func (pf *ProxyForwarder) createSOCKS5Dialer() (proxy.Dialer, error) {
+	// 从代理 URL 中获取认证信息
+	var auth *proxy.Auth
+	if pf.remoteProxy.User != nil {
+		password, _ := pf.remoteProxy.User.Password()
+		auth = &proxy.Auth{
+			User:     pf.remoteProxy.User.Username(),
+			Password: password,
+		}
+	}
+
+	// 创建 SOCKS5 代理地址
+	proxyAddr := fmt.Sprintf("%s:%s", pf.remoteProxy.Hostname(), pf.remoteProxy.Port())
+
+	// 创建 SOCKS5 拨号器
+	dialer, err := proxy.SOCKS5("tcp", proxyAddr, auth, proxy.Direct)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SOCKS5 dialer: %w", err)
+	}
+
+	return dialer, nil
+}
+
+// getAvailableLocalAddr 获取可用的本地地址
+func getAvailableLocalAddr() (string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	defer listener.Close()
+	return listener.Addr().String(), nil
+}
+
+// maskURL 隐藏 URL 中的敏感信息
+func maskURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+
+	masked := *u
+	if masked.User != nil {
+		masked.User = url.UserPassword("****", "****")
+	}
+	return masked.String()
+}


### PR DESCRIPTION
## 功能
  添加对带认证的 SOCKS5/HTTP 代理的支持

  ## 背景
  Chrome 的 --proxy-server 标志不支持嵌入式认证信息
  (http://user:pass@host:port)。本 PR 通过创建本地代理转发器
  来处理认证，使 xiaohongshu-mcp 可以使用带认证的代理。

  ## 改动
  - 新增 `ProxyForwarder` 结构体，自动创建本地 HTTP 代理
  - 支持 SOCKS5 和 HTTP/HTTPS 代理的认证
  - 自动检测代理 URL 中的认证信息并启用转发器
  - 正确处理 HTTPS CONNECT 请求

  ## 使用方式
  ```bash
  # 带认证的 SOCKS5 代理
  XHS_PROXY=socks5://user:pass@host:port ./xiaohongshu-mcp

  # 带认证的 HTTP 代理
  XHS_PROXY=http://user:pass@host:port ./xiaohongshu-mcp

  # 不带认证的代理（直接支持）
  XHS_PROXY=http://host:port ./xiaohongshu-mcp
  ```

  ## 测试结果
  | 测试项 | 无代理 | 带代理 |
  |--------|--------|--------|
  | 获取 IP | 本机 IP | 代理 IP |
  | 搜索功能 | ✅ 正常 | ✅ 正常 |
  | IP 验证 | 112.10.xxx.xxx | 1.71.xx.xx |

  代理功能已验证正常工作，IP 地址正确显示为代理服务器地址。