### PR TITLE
fix: kill Chrome process on Close to prevent zombie/leaked processes

### DIFF
--- a/headless_browser.go
+++ b/headless_browser.go
@@ -144,8 +144,12 @@ func New(options ...Option) *Browser {
 }
 
 // Close closes the browser and cleans up resources.
+// It first attempts a graceful close via the DevTools protocol,
+// then forcefully kills the Chrome process to prevent zombie processes,
+// and finally cleans up the temporary user data directory.
 func (b *Browser) Close() {
 	b.browser.MustClose()
+	b.launcher.Kill()
 	b.launcher.Cleanup()
 }
 


### PR DESCRIPTION
## Problem

When using `headless_browser` in long-running server applications, Chrome processes leak and accumulate over time, eventually exhausting system resources.

**Root cause**: `Close()` calls `browser.MustClose()` (DevTools graceful close) followed by `launcher.Cleanup()` (waits for exit, then removes temp dir). However:

1. If Chrome doesn't respond to the DevTools close command (hangs, unresponsive tab, etc.), the process is never killed
2. `Cleanup()` blocks forever on `<-l.exit` waiting for a process that will never exit
3. Even when `MustClose()` succeeds, there's a race where child processes (renderers, GPU process) may not terminate

**Real-world impact**: In [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp), each API request creates a new browser instance. Leaked Chrome renderer processes accumulated to **load average 500+** on a 16-core server, with each renderer consuming ~78% CPU. The server became essentially unresponsive.

## Fix

Add `launcher.Kill()` between `MustClose()` and `Cleanup()`:

```go
func (b *Browser) Close() {
    b.browser.MustClose()  // graceful close via DevTools
    b.launcher.Kill()      // forcefully kill Chrome process tree
    b.launcher.Cleanup()   // wait for exit + remove temp dir
}
```

- `Kill()` is safe to call even if the process has already exited
- This ensures Chrome and all its child processes are terminated
- `Cleanup()` can then proceed without blocking

## Testing

Before: Chrome processes accumulate indefinitely in long-running applications
After: Chrome processes are reliably cleaned up on every `Close()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)