### PR TITLE
feat: add anti-detection launcher flags

### DIFF
--- a/headless_browser.go
+++ b/headless_browser.go
@@ -106,9 +106,17 @@ func New(options ...Option) *Browser {
 	l := launcher.New().
 		Headless(cfg.Headless).
 		Set("--no-sandbox").
+		// Hide automation traces at launcher level. stealth.MustPage only patches
+		// JS-side fingerprints after page load; these flags close the gap by
+		// preventing navigator.webdriver=true before any script runs.
+		Set("disable-blink-features", "AutomationControlled").
 		Set(
 			"user-agent", cfg.UserAgent,
 		)
+
+	// go-rod injects --enable-automation by default; remove it so the browser
+	// doesn't advertise itself as a controlled instance.
+	l.Delete("enable-automation")
 
 	// Set custom Chrome binary path if provided
 	if cfg.ChromeBinPath != "" {


### PR DESCRIPTION
## Motivation

`stealth.MustPage` (already used in `NewPage`) patches automation traces at
the JavaScript layer, but only *after* a page is created and navigation starts.
Between Chrome's process launch and the first script execution, detectors can
still observe `navigator.webdriver=true` and other automation switches.

This PR closes that gap by hiding the traces at the **launcher level**, so the
browser process never advertises itself as automation-controlled to begin with.

## What

Two minimal additions in `New()`:

1. **`Set("disable-blink-features", "AutomationControlled")`** — adds
   `--disable-blink-features=AutomationControlled` to the Chrome command line.
   This suppresses the `AutomationControlled` blink feature responsible for
   `navigator.webdriver=true`.

2. **`l.Delete("enable-automation")`** — removes the `--enable-automation`
   switch that go-rod's launcher injects by default. Without this, Chrome
   shows the "Chrome is being controlled by automated test software" infobar
   and exposes additional automation flags.

## Why these specifically

These two changes are the lowest-cost, highest-impact launcher-level hardening
recommended by every modern stealth guide (puppeteer-extra-stealth, Patchright,
rebrowser-patches all start here). They complement (don't replace) the
existing `stealth.MustPage` injection.

## Test plan

- `go vet ./...` ✅
- `go build ./...` ✅
- API unchanged — no caller adjustments needed.

## 简要中文说明

`stealth.MustPage` 在 JS 层覆盖自动化痕迹，但浏览器**进程启动到第一次 JS 执行之间**仍会暴露 `navigator.webdriver=true`。本 PR 在 launcher 层补上这层防护：

1. 加 `--disable-blink-features=AutomationControlled` 抑制 blink 注入的 webdriver 标志
2. 移除 go-rod 默认的 `--enable-automation` switch（否则会显示「Chrome 受自动化测试软件控制」提示栏）

不破坏现有 API，调用方零修改。